### PR TITLE
Add support for up to 10 nameservers for the "edu" TLD

### DIFF
--- a/whoisdomain/tld_regexpr.py
+++ b/whoisdomain/tld_regexpr.py
@@ -383,7 +383,7 @@ ZZ["edu"] = {
     "creation_date": r"Domain record activated:\s?(.+)",
     "updated_date": r"Domain record last updated:\s?(.+)",
     "expiration_date": r"Domain expires:\s?(.+)",
-    "name_servers": r"Name Servers:\s?\t(.+)\n\t(.+)\n",
+    "name_servers": r"Name Servers:\s?(?:\t(.+)\n)(?:\t(.+)\n)?(?:\t(.+)\n)?(?:\t(.+)\n)?(?:\t(.+)\n)?(?:\t(.+)\n)?(?:\t(.+)\n)?(?:\t(.+)\n)?(?:\t(.+)\n)?(?:\t(.+)\n)?",
 }
 
 # estonian


### PR DESCRIPTION
EDU domains can return many nameservers in arbitrary order. For example, `miami.edu`:

```
Name Servers:
        A1-122.AKAM.NET
        A14-64.AKAM.NET
        A16-67.AKAM.NET
        A22-65.AKAM.NET
        E1.MIAMI.EDU
        A3-64.AKAM.NET
        A7-65.AKAM.NET
```

The current regex only returns the first 2 matching nameservers, which will vary over time since the name server ordering returned by whois is not fixed.

This PR updates the regex to require one name server, but allow up to 10 total.
