### PR TITLE
Parse partial response option

### DIFF
--- a/whoisdomain/_1_query.py
+++ b/whoisdomain/_1_query.py
@@ -13,6 +13,8 @@ from typing import Dict, List, Optional, Tuple
 CACHE: Dict[str, Tuple[int, str]] = {}
 CACHE_MAX_AGE = 60 * 60 * 48  # 48h
 
+STDBUF_OFF_CMD = ['stdbuf', '-o0']
+
 
 def _cache_load(cf: str) -> None:
     if not os.path.isfile(cf):
@@ -122,6 +124,7 @@ def _do_whois_query(
     server: Optional[str] = None,
     verbose: bool = False,
     timeout: Optional[float] = None,
+    parse_partial_response: bool = False,
     wh: str = "whois",
     simplistic: bool = False,
 ) -> str:
@@ -141,7 +144,8 @@ def _do_whois_query(
 
     # LANG=en is added to make the ".jp" output consist across all environments
     p = subprocess.Popen(
-        cmd,
+        # STDBUF_OFF_CMD needed to not lose data on kill
+        STDBUF_OFF_CMD + cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         env={"LANG": "en"} if dl[-1] in ".jp" else None,
@@ -152,8 +156,12 @@ def _do_whois_query(
     except subprocess.TimeoutExpired:
         # Kill the child process & flush any output buffers
         p.kill()
-        p.communicate()
-        raise WhoisCommandTimeout(f"timeout: query took more then {timeout} seconds")
+        r = p.communicate()[0].decode(errors="ignore")
+        # In most cases whois servers returns partial domain data really fast
+        # after that delay occurs (probably intentional) before returning contact data.
+        # Add this option to cover those cases
+        if not parse_partial_response:
+            raise WhoisCommandTimeout(f"timeout: query took more then {timeout} seconds")
 
     if verbose:
         print(r, file=sys.stderr)
@@ -187,6 +195,7 @@ def do_query(
     server: Optional[str] = None,
     verbose: bool = False,
     timeout: Optional[float] = None,
+    parse_partial_response: bool = False,
     wh: str = "whois",
     simplistic: bool = False,
 ) -> str:
@@ -216,6 +225,7 @@ def do_query(
                 server=server,
                 verbose=verbose,
                 timeout=timeout,
+                parse_partial_response=parse_partial_response,
                 wh=wh,
                 simplistic=simplistic,
             ),

--- a/whoisdomain/__init__.py
+++ b/whoisdomain/__init__.py
@@ -258,6 +258,7 @@ def _doOneLookup(
     with_cleanup_results: bool = False,
     include_raw_whois_text: bool = False,
     timeout: Optional[float] = None,
+    parse_partial_response: bool = False,
     wh: str = "whois",
     simplistic: bool = False,
     withRedacted: bool = False,
@@ -274,6 +275,7 @@ def _doOneLookup(
             server=server,
             verbose=verbose,
             timeout=timeout,
+            parse_partial_response=parse_partial_response,
             wh=wh,
             simplistic=simplistic,
         )
@@ -344,6 +346,7 @@ def query(
     include_raw_whois_text: bool = False,
     return_raw_text_for_unsupported_tld: bool = False,
     timeout: Optional[float] = None,
+    parse_partial_response: bool = False,
     cmd: str = "whois",
     simplistic: bool = False,
     withRedacted: bool = False,
@@ -366,6 +369,8 @@ def query(
     return_raw_text_for_unsupported_tld:
                         if the tld is unsupported, just try it anyway but return only the raw text.
     timeout:            timeout in seconds for the whois command to return a result.
+    parse_partial_response:
+                        try to parse partial response when cmd timed out
     cmd:                explicitly specify the path to the whois you want to use.
     simplistic:         when simplistic is True we return None for most exceptions and dont pass info why we have no data.
     withRedacted:       show redacted output , default no redacted data is shown
@@ -464,6 +469,7 @@ def query(
             with_cleanup_results=with_cleanup_results,
             include_raw_whois_text=include_raw_whois_text,
             timeout=timeout,
+            parse_partial_response=parse_partial_response,
             wh=wh,
             simplistic=simplistic,
             withRedacted=withRedacted,

--- a/whoisdomain/__init__.py
+++ b/whoisdomain/__init__.py
@@ -370,7 +370,7 @@ def query(
                         if the tld is unsupported, just try it anyway but return only the raw text.
     timeout:            timeout in seconds for the whois command to return a result.
     parse_partial_response:
-                        try to parse partial response when cmd timed out
+                        try to parse partial response when cmd timed out (stdbuf should be in PATH for best results)
     cmd:                explicitly specify the path to the whois you want to use.
     simplistic:         when simplistic is True we return None for most exceptions and dont pass info why we have no data.
     withRedacted:       show redacted output , default no redacted data is shown


### PR DESCRIPTION
In case of timeout still try to parse partial response of whois cmd.

Also adding stdbuf to make it work in all environments - piping results right away without waiting for buffer to fill -> dont lose data on kill. 