### PR TITLE
Update .uk and .co.uk regexes to handle up to 10 entries and ignore IP addresses

### DIFF
--- a/whoisdomain/tld_regexpr.py
+++ b/whoisdomain/tld_regexpr.py
@@ -59,7 +59,7 @@ ZZ["co.uk"] = {
     "extend": "uk",
     "domain_name": r"Domain name:\s+(.+)",
     "registrar": r"Registrar:\s+(.+)",
-    "name_servers": r"Name servers:(?:\n\s+(\S+))?(?:\n\s+(\S+))?(?:\n\s+(\S+))?(?:\n\s+(\S+))?\n\n",  # capture up to 4
+    "name_servers": r"Name servers:(?:\n[ \t]+(\S+).*)?(?:\n[ \t]+(\S+).*)?(?:\n[ \t]+(\S+).*)?(?:\n[ \t]+(\S+).*)?(?:\n[ \t]+(\S+).*)?(?:\n[ \t]+(\S+).*)?(?:\n[ \t]+(\S+).*)?(?:\n[ \t]+(\S+).*)?(?:\n[ \t]+(\S+).*)?(?:\n[ \t]+(\S+).*)?\n\n",  # capture up to 10
     "status": r"Registration status:\s*(.+)",
     "creation_date": r"Registered on:(.+)",
     "expiration_date": r"Expiry date:(.+)",
@@ -1114,7 +1114,7 @@ ZZ["uk"] = {
     "creation_date": r"Registered on:\s*(.+)",
     "expiration_date": r"Expiry date:\s*(.+)",
     "updated_date": r"Last updated:\s*(.+)",
-    "name_servers": r"Name Servers:\s*(\S+)\r?\n(?:\s+(\S+)\r?\n)?(?:\s+(\S+)\r?\n)?(?:\s+(\S+)\r?\n)?",
+    "name_servers": r"Name Servers:\s*(\S+).*\r?\n(?:[ \t]+(\S+).*\r?\n)?(?:[ \t]+(\S+).*\r?\n)?(?:[ \t]+(\S+).*\r?\n)?(?:[ \t]+(\S+).*\r?\n)?(?:[ \t]+(\S+).*\r?\n)?(?:[ \t]+(\S+).*\r?\n)?(?:[ \t]+(\S+).*\r?\n)?(?:[ \t]+(\S+).*\r?\n)?(?:[ \t]+(\S+).*\r?\n)?",
     "status": r"Registration status:\n\s*(.+)",
 }
 


### PR DESCRIPTION
`*.uk` and `*.co.uk` domains can return many nameservers, and sometimes provide IPv4 and/or IPv6 info on the nameserver lines:

Eg:
```
    Name servers:
        ns1.livedns.co.uk         217.160.81.244  2001:8d8:fe:53:fa::1
        ns2.livedns.co.uk         217.160.82.244  2001:8d8:fe:53:fa::2
        ns3.livedns.co.uk         185.132.35.244  2607:f1c0:fe:53:185:132:35:244


   Name servers:
        a1-204.akam.net
        a16-67.akam.net
        a24-65.akam.net
        a4-67.akam.net
        a6-64.akam.net
        a7-66.akam.net
```

This PR modifies those regexes are ignore text after the nameservers, and allow up to 10 nameservers to be parsed.