### PR TITLE
parse registrant *organization* in priority for .fr tld

### DIFF
--- a/testFR.py
+++ b/testFR.py
@@ -1,0 +1,12 @@
+#! /usr/bin/env python3.9
+
+import whoisdomain
+
+w_fr = whoisdomain.query("sfr.fr")
+w_com = whoisdomain.query("sfr.com")
+
+print("TEST registrant organization")
+assert w_fr.registrant == "SOCIETE FRANCAISE DU RADIOTELEPHONE - SFR"
+
+# print("TEST that .com and .fr give same results")
+assert w_fr.registrant == w_com.registrant

--- a/whoisdomain/domain.py
+++ b/whoisdomain/domain.py
@@ -83,7 +83,10 @@ class Domain:
             self.reseller = data["reseller"][0].strip()
 
         if "registrant" in data:
-            self.registrant = data["registrant"][0].strip()
+            if "registrant_organization" in data:
+                self.registrant = data["registrant_organization"][0].strip()
+            else:
+                self.registrant = data["registrant"][0].strip()
 
         if "admin" in data:
             self.admin = data["admin"][0].strip()

--- a/whoisdomain/tldDb/tld_regexpr.py
+++ b/whoisdomain/tldDb/tld_regexpr.py
@@ -420,6 +420,7 @@ ZZ["fr"] = {
     "domain_name": r"domain:\s?(.+)",
     "registrar": r"registrar:\s*(.+)",
     "registrant": r"contact:\s?(.+)",
+    "registrant_organization": r"type:\s+ORGANIZATION\scontact:\s+(.*)",
     "creation_date": r"created:\s?(.+)",
     "expiration_date": r"Expiry Date:\s?(.+)",
     "updated_date": r"last-update:\s?(.+)",


### PR DESCRIPTION
Hello,

I got an issue while trying to get registrant with .fr, the whois format with .fr give you many registrant, some are PERSON type, some are ORGANIZATION. The current WhoisDomain implementation is quite random and unpredictable, sometimes it give you the first ORGANIZATION, sometimes the first PERSON. In order to make it more suitable for my needs (I rather prefer organization registrant than persons) and to be more consistent and predictable, I make it always return the first organization found when available and fallback to the first registrant found otherwise.

regards
