### PR TITLE
sync (#51)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,9 +25,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install ruff tld types-redis types-requests python-dateutil whodap
 
-      - name: Run ruff format check
-        run: ruff format --check whoisdomain/
-
       - name: Run ruff lint
         run: ruff check whoisdomain/
 

--- a/whoisdomain/__init__.py
+++ b/whoisdomain/__init__.py
@@ -208,7 +208,7 @@ def q2(
         if dd.status:
             with_rdap_whois = True
             d: dict[str, Any] = wr.map_data_to_whoisdomain(dd.data, with_rdap_whois=with_rdap_whois)
-            d['__lookup__'] = 'rdap'
+            d["__lookup__"] = "rdap"
 
             rr = Domain(pc=pc, dc=dc)
             rr.from_whodap_dict(d)

--- a/whoisdomain/context/parameterContext.py
+++ b/whoisdomain/context/parameterContext.py
@@ -2,7 +2,7 @@
 import json
 import logging
 from dataclasses import asdict, dataclass
-from typing import Any
+
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
* specific C901 ignore

* initial tests whodap

* testing

* use dataresponse with message in case of error

* remove pylint, simplefy ruff

* test whoisdomain formatting with raw

* move classes to files

* testing

* set ruff checks more explicit on items

* cleanup ruff rule errors in the code

* lint clean again

* more ruff rules clarify

* diocument all exceptions in ruff rules

* rdap info first , if none try whois

* cleanup tld db

* testing

* update readme

* update readme

* update readme

* update readme

* update ci cd gh-action

* add flags rdapOnly and whoisOnly

* main now has --whoisOnly and --rdapOnly for testing it

* version 2.20260522.1

* round one Claude code review

* replace parametercontext

* add __lookup__ rdap/whois

* format